### PR TITLE
Changed location for IP 18.228.58.142 from Cape Town to São Paulo

### DIFF
--- a/cloudregions.updated.csv
+++ b/cloudregions.updated.csv
@@ -23,7 +23,7 @@ https://ec2.eu-west-3.amazonaws.com/ping,AWS,Paris,Paris,France,52.46.64.63;
 https://ec2.eu-north-1.amazonaws.com/ping,AWS,Stockholm,Stockholm,Sweden,52.46.192.128;
 https://ec2.me-south-1.amazonaws.com/ping,AWS,Bahrain,Manama,Bahrain,99.82.128.102;
 https://ec2.af-south-1.amazonaws.com/ping,AWS,Cape Town,Cape Town,South Africa,99.78.132.94;
-null,AWS,Cape Town,Cape Town,South Africa,18.228.58.142;
+null,AWS,São Paulo,São Paulo,Brazil,18.228.58.142;
 https://ec2.sa-east-1.amazonaws.com/ping,AWS,São Paulo,São Paulo,Brazil,177.72.245.178;
 null,AWS,São Paulo,São Paulo,Brazil,177.72.245.178;
 https://feitsui-bom.oss-ap-south-1.aliyuncs.com/ping.html,Alibaba,Mumbai,Mumbai,India,149.129.143.66;


### PR DESCRIPTION
Apparently the location of the AWS IP 18.228.58.142 changed from Cape Town, South Africa to São Paulo, Brazil.

Multiple IP location lookup services (e.g. [here](https://www.iplocation.net/ip-lookup) or [here](https://www.showmyip.com/bulk-ip-lookup/)) agree on São Paulo as the location (as of 05.02.2024).

A `whois` run also lists "Amazon Data Services Brazil" as Org, further hinting at a switch from `af-south-1` to `sa-east-1`.

Opening the IP in a web browser leads to a website referencing the TUM Chair of Connected Mobility, ruling out the option that the IP has been reassigned to some unrelated instance by AWS.

Therefore the chairs EC2 instance seems to have been moved to a different AWS region. This PR updates the location in the `cloudregions.updated.csv` file accordingly.